### PR TITLE
Use IgnoreNodeManager for filtering Code node

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/nodaguti/textlint-rule-ginger",
   "repository": "nodaguti/textlint-rule-ginger",
   "dependencies": {
-    "es6-promisify": "^3.0.0",
+    "es6-promisify": "^4.1.0",
     "gingerbread": "^0.5.0",
     "textlint-rule-helper": "^1.1.5",
     "textlint-util-to-string": "^1.2.0",
@@ -40,9 +40,9 @@
     "babel-plugin-espower": "^2.1.2",
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.5.3",
-    "eslint-config-airbnb": "^6.2.0",
+    "eslint-config-airbnb": "^9.0.1",
     "mocha": "^2.4.5",
-    "npm-run-all": "^1.7.0",
+    "npm-run-all": "^2.1.2",
     "power-assert": "^1.3.1",
     "textlint": "^6.2.0",
     "textlint-tester": "^1.2.0"


### PR DESCRIPTION
Hi @nodaguti , I've updated dependecies and improved `Code` filtering logic.
- Use [IgnoreNodeManger](https://github.com/textlint/textlint-rule-helper#class-ignorenodemanger) for  filtering `Code` node.
- Update dependencies
## Before

This is unexpected error.

```
$ echo "\`var a = i;\` is code" > output.md
$ textlint -f pretty-error --rule ginger output.md
✓ ginger: code -> Code
/Users/azu/.ghq/github.com/azu/teasa/output.md:1:1
       v
    0.
    1. `var a = i;` is code
    2.
       ^

✖ 1 problem (1 error, 0 warnings)
✓ 1 fixable problem.
Try to run: $ textlint --fix [file]
```
## After

No error.

What do you think?
