### PR TITLE
feat: add `skipPatterns` option

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,7 +27,7 @@ You can set words to skip assertion with the regular expression.
 ```json
 "rule": {
   "ginger": {
-    "skipRegExps": ["[Jj]ava *[Ss]cript"]
+    "skipPatterns": ["/[Jj]ava *[Ss]cript/"]
   }
 }
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,6 +22,17 @@ $ npm install textlint textlint-rule-ginger
 $ textlint --rule textlint-rule-ginger text-to-proofread.txt
 ```
 
+You can set words to skip assertion with the regular expression.
+
+```json
+"rule": {
+  "ginger": {
+    "skipRegExps": ["[Jj]ava *[Ss]cript"]
+  }
+}
+```
+
+
 ## Tests
 
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,7 +32,6 @@ You can set words to skip assertion with the regular expression.
 }
 ```
 
-
 ## Tests
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "textlint-rule-ginger",
   "version": "2.1.2",
-  "description":
-    "textlint rule to check your English grammar with Ginger Proofreading",
+  "description": "textlint rule to check your English grammar with Ginger Proofreading",
   "engines": {
     "node": ">=6"
   },
@@ -16,8 +15,16 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write \"**/*.{js,json,md}\""
   },
-  "files": ["lib", "src"],
-  "keywords": ["textlint", "rule", "english", "proofreading"],
+  "files": [
+    "lib",
+    "src"
+  ],
+  "keywords": [
+    "textlint",
+    "rule",
+    "english",
+    "proofreading"
+  ],
   "author": "nodaguti",
   "license": "MIT",
   "bugs": "https://github.com/textlint-rule/textlint-rule-ginger/issues",
@@ -46,7 +53,13 @@
     "textlint-tester": "^3.0.3"
   },
   "lint-staged": {
-    "*.js": ["prettier", "git add"],
-    "*.json": ["prettier", "git add"]
+    "*.js": [
+      "prettier",
+      "git add"
+    ],
+    "*.json": [
+      "prettier",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/textlint-rule/textlint-rule-ginger",
   "repository": "textlint-rule/textlint-rule-ginger",
   "dependencies": {
+    "@textlint/regexp-string-matcher": "^1.0.2",
     "es6-promisify": "^5.0.0",
     "gingerbread": "^0.5.0",
     "textlint-rule-helper": "^2.0.0",

--- a/src/ginger.js
+++ b/src/ginger.js
@@ -36,7 +36,7 @@ function filterNode({ node, context }) {
   return { source, text };
 }
 
-function reporter(context) {
+function reporter(context, options={ skipRegExps: [] }) {
   const { Syntax, report, RuleError, fixer } = context;
 
   return {
@@ -55,7 +55,9 @@ function reporter(context) {
           return;
         }
 
-        corrections.forEach((correction) => {
+        corrections.filter((correction) => (
+          !options.skipRegExps.some((r) => RegExp(r).test(correction))
+        )).forEach((correction) => {
           const index = correction.start;
           const originalPosition = source.originalPositionFromIndex(index);
           const originalRange = [

--- a/src/ginger.js
+++ b/src/ginger.js
@@ -36,7 +36,7 @@ function filterNode({ node, context }) {
   return { source, text };
 }
 
-function reporter(context, options={ skipRegExps: [] }) {
+function reporter(context, options = { skipRegExps: [] }) {
   const { Syntax, report, RuleError, fixer } = context;
 
   return {
@@ -55,33 +55,41 @@ function reporter(context, options={ skipRegExps: [] }) {
           return;
         }
 
-        corrections.filter((correction) => (
-          !options.skipRegExps.some((r) => RegExp(r).test(correction))
-        )).forEach((correction) => {
-          const index = correction.start;
-          const originalPosition = source.originalPositionFromIndex(index);
-          const originalRange = [
-            originalPosition.column,
-            originalPosition.column + correction.length,
-          ];
+        corrections
+          .filter(
+            (correction) =>
+              !options.skipRegExps.some((skipRegExp) =>
+                RegExp(skipRegExp).test(correction.text),
+              ),
+          )
+          .forEach((correction) => {
+            const index = correction.start;
+            const originalPosition = source.originalPositionFromIndex(index);
+            const originalRange = [
+              originalPosition.column,
+              originalPosition.column + correction.length,
+            ];
 
-          // if range is ignored, skip reporting
-          if (ignoreNodeManager.isIgnoredRange(originalRange)) {
-            return;
-          }
+            // if range is ignored, skip reporting
+            if (ignoreNodeManager.isIgnoredRange(originalRange)) {
+              return;
+            }
 
-          const fix = fixer.replaceTextRange(originalRange, correction.correct);
-          const message = `${correction.text} -> ${correction.correct}`;
+            const fix = fixer.replaceTextRange(
+              originalRange,
+              correction.correct,
+            );
+            const message = `${correction.text} -> ${correction.correct}`;
 
-          report(
-            node,
-            new RuleError(message, {
-              line: originalPosition.line - 1,
-              column: originalPosition.column,
-              fix,
-            }),
-          );
-        });
+            report(
+              node,
+              new RuleError(message, {
+                line: originalPosition.line - 1,
+                column: originalPosition.column,
+                fix,
+              }),
+            );
+          });
       })();
     },
   };

--- a/src/ginger.js
+++ b/src/ginger.js
@@ -36,7 +36,8 @@ function filterNode({ node, context }) {
   return { source, text };
 }
 
-function reporter(context, options = { skipRegExps: [] }) {
+function reporter(context, options = {}) {
+  const opts = Object.assign({ skipRegExps: [] }, options);
   const { Syntax, report, RuleError, fixer } = context;
 
   return {
@@ -58,7 +59,7 @@ function reporter(context, options = { skipRegExps: [] }) {
         corrections
           .filter(
             (correction) =>
-              !options.skipRegExps.some((skipRegExp) =>
+              !opts.skipRegExps.some((skipRegExp) =>
                 RegExp(skipRegExp).test(correction.text),
               ),
           )

--- a/test/ginger.js
+++ b/test/ginger.js
@@ -8,6 +8,12 @@ tester.run('ginger', rule, {
     'Hello, world!',
     'This sentence contains no mistakes.',
     'Misspellings in inline `codee` should be ignored.',
+    {
+      text: 'This link does not contain an [errror](index.html).',
+      options: {
+        skipRegExps: ['err+or'],
+      },
+    },
   ],
   invalid: [
     {

--- a/test/ginger.js
+++ b/test/ginger.js
@@ -11,7 +11,7 @@ tester.run('ginger', rule, {
     {
       text: 'This link does not contain an [errror](index.html).',
       options: {
-        skipRegExps: ['err+or'],
+        skipPatterns: ['/err+or/'],
       },
     },
   ],


### PR DESCRIPTION
Hello,

Since some jargon cannot be recognized by ginger, I added this options to skip errors.
This feature has already been implemented `textlint-rule-spellchecker`.
For me, it is enough to add this property from `textlint-rule-spellchecker`, however someone may want the other features. Since I have no time to do it, I stop to add the other features.

Anyway, I guess this request make your project to be better.

Thank you!